### PR TITLE
:sparkles: Add pattern filtering feature for release notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GitHub Releases Watcher is a simple Node.js application that monitors specified 
 - Sends email notifications for new releases.
 - Stores the latest release information per repository in a local JSON file.
 - Easy to configure via a YAML file.
+- **Pattern filtering**: Configure regex patterns to filter which releases trigger notifications while still tracking all releases.
 
 ## Prerequisites
 
@@ -45,6 +46,35 @@ Before you begin, ensure you have the following installed:
 
     Open `config.yaml` in your text editor and fill in the details.
 
+### Repository Configuration
+
+You can configure repositories in two ways:
+
+#### Basic Configuration (All releases trigger notifications)
+
+```yaml
+repos:
+  "owner/repository": {}
+```
+
+#### Advanced Configuration with Pattern Filtering
+
+```yaml
+repos:
+  "microsoft/vscode":
+    pattern: "^[A-Za-z]+ [0-9]+$"  # Only releases like "January 2024"
+  "facebook/react":
+    pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+"  # Semantic versioning like "18.2.0 (June 14, 2022)"
+  "other/repo": {}  # No pattern - all releases trigger notifications
+```
+
+**Pattern Behavior:**
+
+- When a `pattern` is specified, only releases whose titles match the regex pattern will trigger email notifications
+- All releases (matching or not) are still saved to the JSON file and logged
+- If no `pattern` is specified, all releases trigger notifications (backward compatible behavior)
+- Use double backslashes (`\\`) to escape regex special characters in YAML
+
 > [!IMPORTANT]
 > `config.yaml` is ignored by Git (via `.gitignore`) to prevent sensitive information (like email passwords) from being committed to your repository.
 
@@ -60,8 +90,9 @@ This will:
 
 1. Read your `config.yaml`.
 2. Check for new releases for each configured repository.
-3. Send an email notification if a new release is found (only the latest one per repository).
-4. Update the `data/releases.json` file with the latest release information.
+3. Send an email notification if a new release is found and matches the configured pattern (if any).
+4. Update the `data/releases.json` file with the latest release information (regardless of pattern matching).
+5. Log any releases that don't match the pattern but were still tracked.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ repos:
 
 - When a `pattern` is specified, only releases whose titles match the regex pattern will trigger email notifications
 - All releases (matching or not) are still saved to the JSON file and logged
-- If no `pattern` is specified, all releases trigger notifications (backward compatible behavior)
+- If no `pattern` is specified, all releases trigger notifications
 - Use double backslashes (`\\`) to escape regex special characters in YAML
 
 > [!IMPORTANT]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,8 @@
 repos:
-  - "microsoft/vscode"
-  - "facebook/react"
+  "microsoft/vscode":
+    pattern: "^[A-Za-z]+ [0-9]+$"
+  "facebook/react":
+    pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+"
 
 mail:
   host: "your.smtp.host"


### PR DESCRIPTION
This pull request introduces a new feature to allow pattern-based filtering of release notifications in the GitHub Releases Watcher application. This enhancement enables users to specify regex patterns for each repository to control which releases trigger email notifications while maintaining backward compatibility. The changes span documentation updates, configuration adjustments, and code modifications to implement and validate this feature.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11): Added details about the new pattern filtering feature, including examples of basic and advanced repository configurations and explanations of pattern behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R77) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R95)

### Configuration Changes:
* [`config.example.yaml`](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aL2-R5): Updated the example configuration file to demonstrate the new `pattern` field for repositories, showcasing regex usage for filtering release notifications.

### Code Enhancements:
* `src/index.ts`:
  - Updated the `Config` interface to support the new `pattern` field within repository configurations.
  - Introduced a `regexCache` for efficient regex reuse and a `isValidPattern` function to validate regex patterns. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R57-R58) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R79-R106)
  - Modified the `main` function to evaluate release titles against the configured patterns and conditionally send notifications. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L115-R143) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R158-R165)
  - Added the `shouldNotifyRelease` function to encapsulate logic for determining whether a release matches a repository's notification criteria.